### PR TITLE
Exit with code 0 if only warnings are present

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -30,7 +30,7 @@ class Reporter {
       output += ' | '
       output += chalk.yellow.bold(`warnings ${totalWarnings}`)
       console.log(output)
-      process.exit(1)
+      process.exit(totalErrors > 0 ? 1 : 0)
     }
   }
 }


### PR DESCRIPTION
The reporter should not fail the process with a non-zero exit code if only warnings were found