### PR TITLE
Conventional "Docker run" behaviour

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,13 @@
 FROM node:8
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json .
+RUN npm install
+
+# Copy our code on top
+COPY lib ./lib
+COPY bin ./bin
+
+ENTRYPOINT ["bin/sass-lint-vue"]

--- a/readme.md
+++ b/readme.md
@@ -48,11 +48,11 @@ docker build . -t sass-lint-vue.
 Lint the `Component.vue` file in the docker container via:
 
 ```bash
-docker run --rm -v (pwd):/app sass-lint-vue ./app/bin/sass-lint-vue ./app/test/Component.vue
+docker run --rm -tv $(pwd)/test:/app/test sass-lint-vue test
 ```
 
 Access the container via:
 
 ```bash
-docker run -it --rm -v (pwd):/app sass-lint-vue bash
+docker run -it --rm -v $(pwd)/test:/app/test --entrypoint bash sass-lint-vue
 ```


### PR DESCRIPTION
Hi team,
The examples in the README do not work out of the box. (You've got to run `npm install` first).

It's something Dockerfiles usually handle so I set one up for you and updated the examples in the doc. A newcomer can just cut & paste the commands from the documentation to get the results.

Hope that helps.
Tom